### PR TITLE
[FEAT] 로그아웃, 회원탈퇴 기능 구현

### DIFF
--- a/src/apis/baseAxios.ts
+++ b/src/apis/baseAxios.ts
@@ -6,10 +6,10 @@ export const baseAxios = axios.create({
 });
 
 baseAxios.interceptors.request.use((config) => {
-  const jwtToken = getCookie('jwtToken') as string;
+  const accessToken = getCookie('accessToken') as string;
 
-  if (jwtToken) {
-    config.headers.Authorization = `Bearer ${jwtToken}`;
+  if (accessToken) {
+    config.headers.Authorization = `Bearer ${accessToken}`;
   }
 
   return config;

--- a/src/apis/deleteDeactivation.ts
+++ b/src/apis/deleteDeactivation.ts
@@ -1,0 +1,12 @@
+import { APIResponse, Deactivation } from '@/data/type';
+import { deleteCookie } from 'cookies-next';
+import { baseAxios } from './baseAxios';
+
+export const deleteDeactivation = async () => {
+  const data = await baseAxios.delete<APIResponse<Deactivation>>('/api/auth/deactivation');
+
+  deleteCookie('accessToken');
+  deleteCookie('refreshToken');
+
+  return data;
+};

--- a/src/apis/postLogin.ts
+++ b/src/apis/postLogin.ts
@@ -1,11 +1,16 @@
+import { APIResponse } from '@/data/type';
 import { baseAxios } from './baseAxios';
 
 export const postLogin = async (authorizationCode: string) => {
-  const data = await baseAxios.post<{
-    accessToken: string;
-    refreshToken: string;
-  }>('api/auth/kakao', {
-    authorizationCode: authorizationCode,
+  const {
+    data: { data },
+  } = await baseAxios.post<
+    APIResponse<{
+      accessToken: string;
+      refreshToken: string;
+    }>
+  >('api/auth/kakao', {
+    authorizationCode,
   });
   return data;
 };

--- a/src/apis/postLogout.ts
+++ b/src/apis/postLogout.ts
@@ -1,0 +1,14 @@
+import { getCookie, deleteCookie } from 'cookies-next';
+import { baseAxios } from './baseAxios';
+import { APIResponse, Logout } from '@/data/type';
+
+export const postLogout = async () => {
+  const data = await baseAxios.post<APIResponse<Logout>>('api/auth/logout', {
+    refreshToken: getCookie('refreshToken'),
+  });
+
+  deleteCookie('accessToken');
+  deleteCookie('refreshToken');
+
+  return data;
+};

--- a/src/components/navigation-modal/navigation-modal.css.ts
+++ b/src/components/navigation-modal/navigation-modal.css.ts
@@ -30,3 +30,33 @@ export const modalButton = css({
   gap: '10px',
   cursor: 'pointer',
 });
+
+export const memberManagement = css({
+  display: 'flex',
+  marginTop: '439px',
+  gap: '40px',
+});
+
+export const memberManagementButton = css({
+  color: 'rgba(255, 255, 255, 0.50)',
+  fontWeight: '800',
+  fontSize: '18px',
+});
+
+export const example = css({
+  position: 'relative',
+  zIndex: 100,
+  borderRadius: '20px',
+  backgroundColor: 'red',
+  width: '300px',
+  height: '50px',
+});
+
+export const exampleSecond = css({
+  position: 'relative',
+  zIndex: 100,
+  borderRadius: '20px',
+  backgroundColor: 'blue',
+  width: '300px',
+  height: '50px',
+});

--- a/src/components/navigation-modal/navigation-modal.tsx
+++ b/src/components/navigation-modal/navigation-modal.tsx
@@ -1,7 +1,12 @@
 import { AnimatePresence, motion } from 'framer-motion';
-import * as navigationModal from './navigation-modal.css';
+import * as Style from './navigation-modal.css';
 import Image from 'next/image';
 import Link from 'next/link';
+import { getCookie } from 'cookies-next';
+import { useState } from 'react';
+import { postLogout } from '@/apis/postLogout';
+import { deleteDeactivation } from '@/apis/deleteDeactivation';
+import { useRouter } from 'next/router';
 
 interface NavigationModalProps {
   isOpen: boolean;
@@ -38,6 +43,95 @@ const navigationList: TabType[] = [
 ];
 
 export default function NavigationModal({ isOpen, onClose }: NavigationModalProps) {
+  const router = useRouter();
+  const accessToken = getCookie('accessToken');
+
+  const [modal, setModal] = useState<{ isOpen: boolean; type: 'login' | 'logout' | 'delete' }>({
+    isOpen: false,
+    type: 'login',
+  });
+
+  const kakaoLogin = () => {
+    window.location.href = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env
+      .NEXT_PUBLIC_KAKAO_REST_API_KEY!}&redirect_uri=${
+      process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI
+    }&response_type=code`;
+  };
+
+  function SwitchModal({ type }: { type: 'login' | 'logout' | 'delete' }) {
+    switch (type) {
+      case 'login':
+        return (
+          <>
+            <button css={Style.example} onClick={() => kakaoLogin()}>
+              login
+            </button>
+            <button
+              css={Style.exampleSecond}
+              onClick={() => {
+                setModal({
+                  isOpen: false,
+                  type: 'login',
+                });
+              }}
+            >
+              닫기
+            </button>
+          </>
+        );
+      case 'logout':
+        return (
+          <>
+            <button
+              css={Style.example}
+              onClick={async () => {
+                await postLogout();
+                router.reload();
+              }}
+            >
+              logout
+            </button>
+            <button
+              css={Style.exampleSecond}
+              onClick={() => {
+                setModal({
+                  isOpen: false,
+                  type: 'logout',
+                });
+              }}
+            >
+              닫기
+            </button>
+          </>
+        );
+      case 'delete':
+        return (
+          <>
+            <button
+              css={Style.example}
+              onClick={async () => {
+                await deleteDeactivation();
+                router.reload();
+              }}
+            >
+              delete
+            </button>
+            <button
+              css={Style.exampleSecond}
+              onClick={() => {
+                setModal({
+                  isOpen: false,
+                  type: 'delete',
+                });
+              }}
+            >
+              닫기
+            </button>
+          </>
+        );
+    }
+  }
+
   return (
     <AnimatePresence>
       {isOpen && (
@@ -47,9 +141,9 @@ export default function NavigationModal({ isOpen, onClose }: NavigationModalProp
           exit={{ opacity: 0, y: 1000 }}
           transition={{ duration: 0.5, ease: 'easeInOut' }}
         >
-          <div css={navigationModal.base}>
-            <header css={navigationModal.modalHeader}>
-              <button css={navigationModal.modalCloseButton} onClick={onClose}>
+          <div css={Style.base}>
+            <header css={Style.modalHeader}>
+              <button css={Style.modalCloseButton} onClick={onClose}>
                 <Image
                   alt="exit-button"
                   src="/assets/svgs/IconArrowBack.svg"
@@ -63,9 +157,8 @@ export default function NavigationModal({ isOpen, onClose }: NavigationModalProp
                 <motion.div
                   initial={{ opacity: 0, y: 0 }}
                   animate={{ opacity: 1, y: 0 }}
-                  // exit={{ opacity: 0, y: 1000 }}
                   transition={{ duration: 1.3, ease: 'easeInOut' }}
-                  css={navigationModal.modalButton}
+                  css={Style.modalButton}
                 >
                   <p>{tab.title}</p>
                   <Image
@@ -77,7 +170,60 @@ export default function NavigationModal({ isOpen, onClose }: NavigationModalProp
                 </motion.div>
               </Link>
             ))}
+            <div>
+              {accessToken ? (
+                <motion.div
+                  initial={{ opacity: 0, y: 0 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 1.3, ease: 'easeInOut' }}
+                  css={Style.memberManagement}
+                >
+                  <button
+                    css={Style.memberManagementButton}
+                    onClick={() => {
+                      setModal({
+                        isOpen: true,
+                        type: 'logout',
+                      });
+                    }}
+                  >
+                    로그아웃
+                  </button>
+                  <button
+                    css={Style.memberManagementButton}
+                    onClick={() => {
+                      setModal({
+                        isOpen: true,
+                        type: 'delete',
+                      });
+                    }}
+                  >
+                    회원탈퇴
+                  </button>
+                </motion.div>
+              ) : (
+                <motion.div
+                  initial={{ opacity: 0, y: 0 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 1.3, ease: 'easeInOut' }}
+                  css={Style.memberManagement}
+                >
+                  <button
+                    css={Style.memberManagementButton}
+                    onClick={() => {
+                      setModal({
+                        isOpen: true,
+                        type: 'login',
+                      });
+                    }}
+                  >
+                    로그인
+                  </button>
+                </motion.div>
+              )}
+            </div>
           </div>
+          {modal.isOpen && <SwitchModal type={modal.type} />}
         </motion.div>
       )}
     </AnimatePresence>

--- a/src/data/type.ts
+++ b/src/data/type.ts
@@ -40,3 +40,11 @@ export type InfinitePostData = {
   first: boolean;
   empty: boolean;
 };
+
+export type Logout = {
+  data: string;
+};
+
+export type Deactivation = {
+  data: string;
+};

--- a/src/pages/redirect/index.tsx
+++ b/src/pages/redirect/index.tsx
@@ -8,9 +8,11 @@ const Redirect = () => {
 
   const getAuth = async (code: string) => {
     const data = await postLogin(code);
-    const accessToken = data.data.accessToken;
+    const accessToken = data.accessToken;
+    const refreshToken = data.refreshToken;
     if ({ data }) {
       setCookie('accessToken', accessToken);
+      setCookie('refreshToken', refreshToken);
     }
     router.push('/home');
   };

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -138,6 +138,7 @@ const styles = css`
   button {
     border: none;
     cursor: pointer;
+    background: none;
   }
 
   a {


### PR DESCRIPTION
## 관련 이슈
close #36 

## 작업 내역
**1. 회원 관리 모달 관련**
- 현재 회원 관리(로그인, 로그아웃, 회원탈퇴) 모두 모달을 사용하고 있습니다.
- 따라서 `SwitchModal`을 통해 모달의 type을 확인하여 모달을 관리하고자 하였습니다.

**2. 로그아웃 & 회원탈퇴 기능 구현**
- api 통신 후, `deleteCookie`를 통해 쿠키 데이터 역시 삭제하였습니다.
- 회원탈퇴의 경우, `interceptors`를 통해 구현하였습니다.

## 작업 화면
https://github.com/YouAndMyFuBao/fubao-client/assets/97885933/d362336a-0e4e-4251-91ee-9eed51f51151

## 전달 사항
- BottomSheet 컴포넌트 관련 회의가 필요할 거 같습니당...!