### PR TITLE
[FIX] Button 컴포넌트 수정

### DIFF
--- a/src/components/button-group/button-group.css.ts
+++ b/src/components/button-group/button-group.css.ts
@@ -1,0 +1,53 @@
+import { SerializedStyles, css } from '@emotion/react';
+import { ComponentProps } from 'react';
+import { ButtonGroup } from './button-group';
+
+type ButtonGroupProps = ComponentProps<typeof ButtonGroup>;
+
+export const base = css({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  fontSize: '17px',
+  fontWeight: '600',
+  borderRadius: '16px',
+});
+
+export const sizeCss: Record<NonNullable<ButtonGroupProps['size']>, SerializedStyles> = {
+  small: css({ width: '100px', height: '56px' }),
+  medium: css({ width: '172px', height: '56px' }),
+};
+
+export const leftCss: Record<ButtonGroupProps['variants'], SerializedStyles> = {
+  'two-button-enable-black': css({
+    backgroundColor: 'white',
+    color: '#1E212B',
+    boxShadow: '0px 0px 16px 2px rgba(0, 0, 0, 0.02)',
+  }),
+  'two-button-enable-green': css({
+    backgroundColor: 'white',
+    color: '#1E212B',
+    boxShadow: '0px 0px 16px 2px rgba(0, 0, 0, 0.02)',
+  }),
+  modal: css({
+    backgroundColor: '#A7C2B1',
+    color: '#1E212B',
+  }),
+};
+
+export const rightCss: Record<ButtonGroupProps['variants'], SerializedStyles> = {
+  'two-button-enable-black': css({
+    backgroundColor: '#1E212B',
+    color: 'white',
+    boxShadow: '0px 0px 16px 2px rgba(0, 0, 0, 0.02)',
+  }),
+  'two-button-enable-green': css({
+    backgroundColor: '#009436',
+    color: 'white',
+    boxShadow: '0px 0px 16px 2px rgba(0, 0, 0, 0.12)',
+  }),
+  modal: css({
+    backgroundColor: '#009436',
+    color: 'white',
+  }),
+};

--- a/src/components/button-group/button-group.stories.ts
+++ b/src/components/button-group/button-group.stories.ts
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ButtonGroup } from './button-group';
+
+const meta: Meta<typeof ButtonGroup> = {
+  title: 'Common/ButtonGroup',
+  component: ButtonGroup,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ButtonGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Example: Story = {
+  args: {
+    variants: 'two-button-enable-black',
+    size: 'small',
+    children: 'ButtonGroup',
+  },
+};

--- a/src/components/button-group/button-group.stories.ts
+++ b/src/components/button-group/button-group.stories.ts
@@ -18,6 +18,6 @@ export const Example: Story = {
   args: {
     variants: 'two-button-enable-black',
     size: 'small',
-    children: 'ButtonGroup',
+    children: 'Group',
   },
 };

--- a/src/components/button-group/button-group.tsx
+++ b/src/components/button-group/button-group.tsx
@@ -1,0 +1,31 @@
+import * as Style from './button-group.css';
+
+interface ButtonGroupProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variants: 'two-button-enable-black' | 'two-button-enable-green' | 'modal';
+  size?: 'small' | 'medium';
+  disabled?: boolean;
+  onClick?: () => void;
+}
+
+export const ButtonGroup = ({
+  variants,
+  type = 'button',
+  size = 'medium',
+  disabled,
+  children,
+  ...props
+}: ButtonGroupProps) => {
+  const buttonLeftCss = [Style.base, Style.leftCss[variants], Style.sizeCss[size]];
+  const buttonRightCss = [Style.base, Style.rightCss[variants], Style.sizeCss[size]];
+
+  return (
+    <div style={{ display: 'flex', gap: '10px' }}>
+      <button type={type} css={buttonLeftCss} disabled={disabled} {...props}>
+        {children}
+      </button>
+      <button type={type} css={buttonRightCss} disabled={disabled} {...props}>
+        {children}
+      </button>
+    </div>
+  );
+};

--- a/src/components/button/button.css.ts
+++ b/src/components/button/button.css.ts
@@ -11,39 +11,19 @@ export const base = css({
   fontSize: '17px',
   fontWeight: '600',
   borderRadius: '16px',
+  width: '354px',
+  height: '56px',
 });
 
 export const variantsCss: Record<ButtonProps['variants'], SerializedStyles> = {
-  primary: css({
+  'one-button-enable-none': css({
     backgroundColor: '#1E212B',
     color: 'white',
     boxShadow: '0px 0px 16px 2px rgba(0, 0, 0, 0.02)',
     '&:disabled': {
-      backgroundColor: '#909190',
+      backgroundColor: '#A7C2B1',
+      color: 'white',
       cursor: 'default',
     },
   }),
-  secondary: css({
-    backgroundColor: 'white',
-    color: '#1E212B',
-    boxShadow: '0px 0px 16px 2px rgba(0, 0, 0, 0.12)',
-  }),
-  'green-primary': css({
-    backgroundColor: '#009436',
-    color: 'white',
-  }),
-  'green-secondary': css({
-    backgroundColor: '#A7C2B1',
-    color: '#1E212B',
-  }),
-  login: css({
-    backgroundColor: '#FEE500',
-    color: '#000',
-  }),
-};
-
-export const sizeCss: Record<NonNullable<ButtonProps['size']>, SerializedStyles> = {
-  small: css({ width: '100px', height: '56px' }),
-  medium: css({ width: '172px', height: '56px' }),
-  large: css({ width: '354px', height: '56px' }),
 };

--- a/src/components/button/button.stories.ts
+++ b/src/components/button/button.stories.ts
@@ -16,22 +16,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Example: Story = {
   args: {
-    variants: 'primary',
-    size: 'small',
+    variants: 'one-button-enable-none',
     children: 'Button',
   },
 };
-
-// export const Middle: Story = {
-//   args: {
-//     size: 'medium',
-//     children: 'Button',
-//   },
-// };
-
-// export const Large: Story = {
-//   args: {
-//     size: 'large',
-//     children: 'Button',
-//   },
-// };

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,8 +1,7 @@
 import * as Style from './button.css';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variants: 'primary' | 'secondary' | 'green-primary' | 'green-secondary' | 'login';
-  size?: 'small' | 'medium' | 'large';
+  variants: 'one-button-enable-none';
   disabled?: boolean;
   onClick?: () => void;
 }
@@ -10,12 +9,11 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 export const Button = ({
   variants,
   type = 'button',
-  size = 'medium',
   disabled,
   children,
   ...props
 }: ButtonProps) => {
-  const buttonCss = [Style.base, Style.variantsCss[variants], Style.sizeCss[size]];
+  const buttonCss = [Style.base, Style.variantsCss[variants]];
 
   return (
     <button type={type} css={buttonCss} disabled={disabled} {...props}>


### PR DESCRIPTION
## 관련 이슈
close #38 

## 작업 내역
**1. Button 컴포넌트 수정**
- 이전 Button 컴포넌트 관련 [PR 링크](https://github.com/YouAndMyFuBao/fubao-client/pull/24)
- 디자인 변경에 따라 Button 컴포넌트 수정을 진행하였습니다.
- 기존의 Button 컴포넌트에서 `ButtonGroup`, `Button` 컴포넌트로 분리하였습니다.

|변경 전|변경 후|
|:---:|:---:|
|![](https://github.com/YouAndMyFuBao/fubao-client/assets/97885933/446cc3b8-73ce-4249-8790-6de202da77c4)'|![](https://github.com/YouAndMyFuBao/fubao-client/assets/97885933/a91cc76d-c11c-4f6f-a9e6-54ba9dd84279)|

**2. Button 컴포넌트**
- size가 하나로 고정되어 있고, 비활성화/활성화 여부만 선택할 수 있게 되어 있습니다.
- 따라서 variants를 우선 `one-button-enable-none` 하나로 두고, disabled 상태에 `one-button-unable-none` 색상을 적용하도록 하였습니다.

**3. ButtonGroup 컴포넌트**
- variants를 `two-button-enable-black`, `two-button-enable-green`, `modal`로 두어 관리하였습니다.

## 작업 화면
[Button]

https://github.com/YouAndMyFuBao/fubao-client/assets/97885933/ab2ad76f-a09e-4930-902c-47b819f63adb

[ButtonGroup]

https://github.com/YouAndMyFuBao/fubao-client/assets/97885933/b8a3d9f0-2953-4d5f-93e5-714a624ac9b5

