### PR TITLE
[FIX] 홈 화면 수정

### DIFF
--- a/src/apis/getFubaoLove.ts
+++ b/src/apis/getFubaoLove.ts
@@ -1,0 +1,9 @@
+// 푸바오 받은 사랑
+import { baseAxios } from './baseAxios';
+import { APIResponse, ReceivedLove } from '@/data/type';
+
+export const getFubaoLove = async () => {
+  const data = await baseAxios.get<APIResponse<ReceivedLove>>(`/api/posts/fubao/love`);
+  console.log('푸바오 받은 사랑', data.data);
+  return data.data;
+};

--- a/src/apis/getFubaoLove.ts
+++ b/src/apis/getFubaoLove.ts
@@ -4,6 +4,5 @@ import { APIResponse, ReceivedLove } from '@/data/type';
 
 export const getFubaoLove = async () => {
   const data = await baseAxios.get<APIResponse<ReceivedLove>>(`/api/posts/fubao/love`);
-  console.log('푸바오 받은 사랑', data.data);
   return data.data;
 };

--- a/src/apis/postFubaoLove.ts
+++ b/src/apis/postFubaoLove.ts
@@ -4,6 +4,6 @@ import { baseAxios } from './baseAxios';
 
 export const postFubaoLove = async () => {
   const data = await baseAxios.post<APIResponse<DeliverLove>>('/api/posts/fubao/love');
-  console.log('푸바오에게 사랑 보내기', data);
-  return data;
+  console.log('푸바오에게 사랑 보내기', data.data);
+  return data.data;
 };

--- a/src/apis/postFubaoLove.ts
+++ b/src/apis/postFubaoLove.ts
@@ -1,9 +1,9 @@
 // 푸바오에게 사랑 보내기
-import { APIResponse, Deactivation } from '@/data/type';
+import { APIResponse, DeliverLove } from '@/data/type';
 import { baseAxios } from './baseAxios';
 
 export const postFubaoLove = async () => {
-  const data = await baseAxios.post<APIResponse<Deactivation>>('/api/posts/fubao/love');
+  const data = await baseAxios.post<APIResponse<DeliverLove>>('/api/posts/fubao/love');
   console.log('푸바오에게 사랑 보내기', data);
   return data;
 };

--- a/src/apis/postFubaoLove.ts
+++ b/src/apis/postFubaoLove.ts
@@ -1,0 +1,9 @@
+// 푸바오에게 사랑 보내기
+import { APIResponse, Deactivation } from '@/data/type';
+import { baseAxios } from './baseAxios';
+
+export const postFubaoLove = async () => {
+  const data = await baseAxios.post<APIResponse<Deactivation>>('/api/posts/fubao/love');
+  console.log('푸바오에게 사랑 보내기', data);
+  return data;
+};

--- a/src/components/navigation-modal/navigation-modal.tsx
+++ b/src/components/navigation-modal/navigation-modal.tsx
@@ -140,7 +140,7 @@ export default function NavigationModal({ isOpen, onClose }: NavigationModalProp
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: 1000 }}
           transition={{ duration: 0.5, ease: 'easeInOut' }}
-          css={navigationModal.motion}
+          css={Style.motion}
         >
           <div css={Style.base}>
             <header css={Style.modalHeader}>

--- a/src/data/type.ts
+++ b/src/data/type.ts
@@ -49,6 +49,10 @@ export type Deactivation = {
   data: string;
 };
 
+export type DeliverLove = {
+  message: string;
+};
+
 export type ReceivedLove = {
   love: number;
 };

--- a/src/data/type.ts
+++ b/src/data/type.ts
@@ -48,3 +48,7 @@ export type Logout = {
 export type Deactivation = {
   data: string;
 };
+
+export type ReceivedLove = {
+  love: number;
+};

--- a/src/pages/home/_components/home-message-bottom.tsx
+++ b/src/pages/home/_components/home-message-bottom.tsx
@@ -1,6 +1,11 @@
 import * as Style from './home-message-bottom.css';
+import { useQuery } from '@tanstack/react-query';
+import { getFubaoLove } from '../../../apis/getFubaoLove';
 
 export default function HomeMessageBottom() {
-  const visitors = 100;
-  return <p css={Style.base}>지금까지 바오에게 전달된 사랑은 총 {visitors}개</p>;
+  const { data: loveData } = useQuery({
+    queryKey: ['fubaoLove'],
+    queryFn: getFubaoLove,
+  });
+  return <p css={Style.base}>지금까지 바오에게 전달된 사랑은 총 {loveData?.data.love}개</p>;
 }

--- a/src/pages/home/_components/home-message.tsx
+++ b/src/pages/home/_components/home-message.tsx
@@ -1,14 +1,18 @@
 import { motion } from 'framer-motion';
 import * as Style from './home-message.css';
-
+import { useQuery } from '@tanstack/react-query';
+import { getFubaoLove } from '../../../apis/getFubaoLove';
 interface HomeMessageProps {
   scratchableEnd: boolean;
 }
 
 export default function HomeMessage({ scratchableEnd }: HomeMessageProps) {
-  const heartCount = 10;
+  const { data: loveData } = useQuery({
+    queryKey: ['fubaoLove'],
+    queryFn: getFubaoLove,
+  });
   const beforeMessage = `하트를 문질러서 \n 푸바오를 만나보세요 !`;
-  const afterMessage = `지금까지 바오에게 \n 전달된 사랑은 총 ${heartCount} 개`;
+  const afterMessage = `지금까지 바오에게 \n 전달된 사랑은 총 ${loveData?.data.love} 개`;
   return (
     <motion.div
       animate={{

--- a/src/pages/home/_components/scratchable-image.tsx
+++ b/src/pages/home/_components/scratchable-image.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Scratchable, ScratchableEvent } from 'scratchable';
 import * as Style from './scratchable-image.css';
+import { postFubaoLove } from '@/apis/postFubaoLove';
 
 interface ScratchableImageProps {
   onScratchEnd: () => void;
@@ -31,6 +32,8 @@ export default function ScratchableImage({ onScratchEnd }: ScratchableImageProps
       if (e.percentage > 0.5) {
         scratchable.destroy();
         onScratchEnd();
+        postFubaoLove();
+        console.log('푸바오 사랑 보내기 완료');
       }
     };
 

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -6,6 +6,7 @@ import HomeMessageBottom from './_components/home-message-bottom';
 import { useRouter } from 'next/router';
 import { getCookie } from 'cookies-next';
 import MyLetterButton from './_components/my-letter-button';
+import CopyLink from '@/components/copy-link/copy-link';
 
 const Home = () => {
   const [scratch, setScratch] = useState(false);
@@ -33,7 +34,7 @@ const Home = () => {
       {scratch && cookie && <MyLetterButton onClick={() => router.push('/my-letter')} />}
       {scratch && (
         <>
-          <button>링크 복사하기</button>
+          <CopyLink />
           <div>
             <button onClick={() => router.reload()}>다시 하트주기</button>
             <button onClick={() => router.push('/letter')}>편지 쓰러가기</button>


### PR DESCRIPTION
## 관련 이슈
close #43 

## 작업 내역
**1. 링크 복사하기 컴포넌트 사용**
- 기존에 마크업만 해두었던 링크 복사하기를, `링크 복사하기` 컴포넌트로 변경하였습니다.

**2. 푸바오 받은 사랑 기능 구현**
- 화면에 노출되는 푸바오가 받은 사랑 개수를 노출시키는 기능을 구현하였습니다.
- 같은 api이기 때문에`home-message`와 `home-message-bottom`을 한번에 구현하면 좋을 것 같은데 우선은 컴포넌트를 따로 분리하여 구현하였습니다. 추후에 리팩토링 해보도록 하겠습니다...!

**3. 푸바오에게 사랑 보내기 기능 구현**
- 사진 스크래치가 끝나면 푸바오에게 사랑을 보내는 기능을 구현하였습니다.

## 작업 화면
https://github.com/YouAndMyFuBao/fubao-client/assets/97885933/36020ca6-26bc-4461-b8b7-52cc39525644

## 전달 사항
- 실시간으로 하트 개수가 업데이트되는 거 같지는 않아서, 이 부분은 계속 고민해 보아야 할 것 같습니다.