### PR TITLE
[FEAT] 편지 확인 페이지 내 헤더 기능 추가

### DIFF
--- a/src/pages/letter/preview/[id].tsx
+++ b/src/pages/letter/preview/[id].tsx
@@ -154,7 +154,14 @@ export default function PreviewLetterWithId() {
         {isBackgroundHandVersion ? backgroundHandVersion() : backgroundHeadVersion()}
         <div css={Style.pageWrapper}>
           <div ref={element1Ref}>
-            {isMounted && accessToken ? <Header rightDoneButton /> : <Header rightCloseButton />}
+            {isMounted && accessToken ? (
+              <Header rightDoneButton onClick={() => router.push('/home')} />
+            ) : (
+              <Header
+                rightCloseButton
+                onClick={() => window.open('about:blank', '_self')?.close()}
+              />
+            )}
           </div>
           {data && <div>{LetterCardWithCss({ data })}</div>}
           <div css={Style.footer.btnGroup} ref={element2Ref}>


### PR DESCRIPTION
## 관련 이슈
- close #66

## 작업 내역
**1.편지 미리보기 화면의 헤더 기능 연결**
- 로그인시 '완료' -> /home으로 이동
- 비로그인시 '닫기' -> 브라우저 창을 닫고자하였으나 **이슈 발생**

## 전달 사항
- 브라우저 닫기를 위해서는 window.close()를 사용해야하는데, 이를 위해서는 window.open()으로 열린 창만 닫기가 가능합니다. (https://developer.mozilla.org/en-US/docs/Web/API/Window/close#closing_a_window_opened_with_window.open) 현재처럼 url을 입력하여 들어온 경우, 창을 닫을 방법은 없어보입니다.
=> 그래서 현재는 `onClick={() => window.open('about:blank', '_self')?.close()}`로 작성하여 '닫기' 클릭시 about:blank를 띄우도록 설정해두었습니다. **이에 혹시 의견이 있으시다면 남겨주셔도 좋을거같아요!**