### PR TITLE
[FEAT] 내가 쓴 편지 수정하기 > 상세보기, 수정하기 화면 추가

### DIFF
--- a/src/components/letter-card/letter-card.tsx
+++ b/src/components/letter-card/letter-card.tsx
@@ -18,6 +18,7 @@ interface DateCardProps {
   apiText: string;
   apiDate: string;
   style?: React.CSSProperties;
+  onClick?: () => void;
 }
 
 type LetterCardProps = TextCountCardProps | DateCardProps;

--- a/src/pages/my-letter/edit/[id].css.tsx
+++ b/src/pages/my-letter/edit/[id].css.tsx
@@ -1,0 +1,19 @@
+import { css } from '@emotion/react';
+
+export const wrapper = css({
+  height: '100vh',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+});
+
+export const main = {
+  card: css({
+    margin: '30px',
+    flexGrow: '1',
+  }),
+
+  button: css({
+    margin: '12px',
+  }),
+};

--- a/src/pages/my-letter/edit/[id].tsx
+++ b/src/pages/my-letter/edit/[id].tsx
@@ -1,0 +1,55 @@
+import Header from '@/components/header/header';
+import LetterCard from '@/components/letter-card/letter-card';
+import * as Style from './[id].css';
+import { useGetPost } from '@/apis/getPost';
+import DateTimeFormat from '@/utils/dateTimeFormat';
+import { useLetterContext } from '@/hooks/useLetterContext';
+import { patchPost } from '@/apis/patchPost';
+import { useRouter } from 'next/router';
+import { useMutation } from '@tanstack/react-query';
+import Button from '@/components/button';
+
+export default function Edit() {
+  const router = useRouter();
+  const activePostId = Number(router.query.activePostId);
+  const { letterImage, letterText } = useLetterContext();
+
+  const { data } = useGetPost({ postId: activePostId });
+
+  const { mutate, data: patchData } = useMutation({
+    mutationKey: ['patchPost', activePostId],
+    mutationFn: () => patchPost({ postId: activePostId, image: letterImage, content: letterText }),
+    onSuccess: (data) => {
+      console.log('patchSuccess', data);
+      router.push(`/my-letter`);
+    },
+  });
+
+  const handleSubmitClick = async () => {
+    mutate();
+    console.log('patchData', patchData);
+  };
+
+  return (
+    <div css={Style.wrapper}>
+      <Header leftBackPage hasLeftBackModal={false}>
+        편지 수정하기
+      </Header>
+      <div css={Style.main.card}>
+        {data && (
+          <LetterCard
+            variant="textCount"
+            apiImage={data?.data.imageUrl}
+            apiText={data?.data.content}
+            apiDate={DateTimeFormat(data?.data.date)}
+          />
+        )}
+      </div>
+      <div css={Style.main.button}>
+        <Button variants="primary" onClick={handleSubmitClick}>
+          수정 완료하기
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/my-letter/edit/[id].tsx
+++ b/src/pages/my-letter/edit/[id].tsx
@@ -21,7 +21,7 @@ export default function Edit() {
     mutationFn: () => patchPost({ postId: activePostId, image: letterImage, content: letterText }),
     onSuccess: (data) => {
       console.log('patchSuccess', data);
-      router.push(`/my-letter`);
+      router.back();
     },
   });
 

--- a/src/pages/my-letter/index.tsx
+++ b/src/pages/my-letter/index.tsx
@@ -9,6 +9,7 @@ import * as Style from './my-letter.css';
 import { BottomSheet } from '@/components/bottom-sheet/bottom-sheet';
 import { useState, useEffect } from 'react';
 import { deletePost } from '@/apis/deletePost';
+import { useRouter } from 'next/router';
 
 export default () => {
   const { data: letterData } = useQuery({
@@ -16,6 +17,7 @@ export default () => {
     queryFn: getMyLetter,
   });
 
+  const router = useRouter();
   const [mounted, setMounted] = useState<boolean>(false);
 
   useEffect(() => {
@@ -63,7 +65,18 @@ export default () => {
                   apiDate={letter.date}
                   apiImage={letter.imageUrl}
                   apiText={letter.content}
-                  style={{ width: '330px' }}
+                  style={{ width: '330px', cursor: 'pointer' }}
+                  onClick={() =>
+                    router.push(
+                      {
+                        pathname: `/my-letter/preview?postId=${activePostId}`,
+                        query: {
+                          activePostId: activePostId,
+                        },
+                      },
+                      `/my-letter/preview/${activePostId}`,
+                    )
+                  }
                 />
               </SwiperSlide>
             ))}
@@ -108,7 +121,20 @@ export default () => {
                   <BottomSheet.Close asChild>
                     <Button variants="quanternary">닫기</Button>
                   </BottomSheet.Close>
-                  <Button variants="tertiary">수정하기</Button>
+                  <Button
+                    variants="tertiary"
+                    onClick={() =>
+                      router.push(
+                        {
+                          pathname: `/my-letter/edit/${activePostId}`,
+                          query: { activePostId: activePostId },
+                        },
+                        `/my-letter/edit/${activePostId}`,
+                      )
+                    }
+                  >
+                    수정하기
+                  </Button>
                 </BottomSheet.BottomCTA>
               </BottomSheet.Content>
             </BottomSheet.Portal>

--- a/src/pages/my-letter/preview/[id].css.tsx
+++ b/src/pages/my-letter/preview/[id].css.tsx
@@ -1,0 +1,68 @@
+import { css } from '@emotion/react';
+
+export const previewLetterStyles = {
+  postWrapper: css({
+    position: 'relative',
+  }),
+};
+
+export const backgroundWrapper = css({
+  position: 'relative',
+  height: '100vh',
+});
+
+export const background = {
+  hand: css({
+    position: 'absolute',
+    right: '0',
+    top: '47vh',
+  }),
+  finger: css({
+    position: 'absolute',
+    right: '0',
+    top: '57vh',
+    zIndex: '1',
+  }),
+  head: css({
+    position: 'absolute',
+    top: '65vh',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    zIndex: '1',
+  }),
+};
+
+export const pageWrapper = css({
+  width: '100%',
+});
+
+export const mainLetterCard = {
+  hand: css({
+    position: 'absolute',
+    top: '100px',
+    right: '90px',
+    transform: 'rotate(-15deg)',
+  }),
+  head: css({
+    position: 'absolute',
+    top: '75px',
+    left: '80px',
+    transform: 'rotate(6.66deg)',
+  }),
+};
+
+export const footer = {
+  btnGroup: css({
+    width: '350px',
+    position: 'fixed',
+    bottom: '10px',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    zIndex: '10',
+  }),
+  bottombtn: css({
+    display: 'flex',
+    flexDirection: 'row',
+    gap: '10px',
+  }),
+};

--- a/src/pages/my-letter/preview/[id].tsx
+++ b/src/pages/my-letter/preview/[id].tsx
@@ -1,0 +1,194 @@
+import Header from '@/components/header/header';
+import {
+  BackgroundPreviewFinger,
+  BackgroundPreviewHand,
+  BackgroundPreviewHead,
+} from '../../../../public/assets/svgs';
+import * as Style from './[id].css';
+import { useEffect, useRef, useState } from 'react';
+import CopyLink from '@/components/copy-link/copy-link';
+import LetterCard from '@/components/letter-card/letter-card';
+import { getPost } from '@/apis/getPost';
+import { APIResponse, PostData } from '@/data/type';
+import DateTimeFormat from '@/utils/dateTimeFormat';
+import { useRouter } from 'next/router';
+import { useQuery } from '@tanstack/react-query';
+import html2canvas from 'html2canvas';
+import Button from '@/components/button';
+import { getCookie } from 'cookies-next';
+import { getImage } from '@/apis/getImage';
+
+export default function PreviewMyLetter() {
+  const router = useRouter();
+  const activePostId = Number(router.query.id);
+
+  console.log('acivePostId', activePostId);
+
+  const accessToken = getCookie('accessToken');
+
+  const { data } = useQuery<APIResponse<PostData>>({
+    queryKey: ['getPost'],
+    queryFn: () => getPost({ postId: activePostId }),
+    enabled: !!activePostId,
+  });
+
+  const { data: imageUrl } = useQuery({
+    queryKey: ['getImage'],
+    queryFn: () => (activePostId ? getImage({ postId: activePostId }) : Promise.resolve({})),
+    enabled: !!activePostId,
+  });
+
+  const [isBackgroundHandVersion, setIsBackgroundHandVersion] = useState(true);
+  const [isMounted, setIsMounted] = useState<boolean>(false);
+
+  const element1Ref = useRef<HTMLDivElement | null>(null);
+  const element2Ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  useEffect(() => {
+    const randomNumber = Math.random();
+    setIsBackgroundHandVersion(randomNumber < 0.5 ? true : false);
+  }, [isBackgroundHandVersion]);
+
+  const handleDownload = async () => {
+    const element1 = element1Ref.current;
+    const element2 = element2Ref.current;
+
+    if (element1 && element2) {
+      hideElements(element1, element2);
+    }
+
+    const page = document.querySelector('#letter');
+
+    try {
+      const canvas = await html2canvas(page as HTMLElement, {
+        backgroundColor: '#009436',
+      });
+
+      const link = document.createElement('a');
+      link.href = canvas.toDataURL('image/png');
+      link.download = 'LetterToFubao.png';
+      link.click();
+
+      showElements(element2, element1);
+    } catch (error) {
+      console.error('html2canvas error');
+    }
+  };
+
+  const hideElements = (...elements: (HTMLDivElement | null)[]) => {
+    elements.forEach((element) => {
+      if (element) {
+        element.style.display = 'none';
+      }
+    });
+  };
+
+  const showElements = (...elements: (HTMLDivElement | null)[]) => {
+    elements.forEach((element) => {
+      if (element) {
+        element.style.display = 'block';
+      }
+    });
+  };
+
+  const backgroundHandVersion = () => {
+    return (
+      <div className="background">
+        <div css={Style.background.hand}>
+          <BackgroundPreviewHand />
+        </div>
+        <div css={Style.background.finger}>
+          <BackgroundPreviewFinger />
+        </div>
+      </div>
+    );
+  };
+
+  const backgroundHeadVersion = () => {
+    return (
+      <div className="background" css={Style.background.head}>
+        <BackgroundPreviewHead />
+      </div>
+    );
+  };
+
+  const LetterCardWithCss = ({ data }: { data: APIResponse<PostData> }) => {
+    const base = 'data:image/png;base64,';
+    const imageUrlAsBase64 = base + imageUrl;
+
+    if (isBackgroundHandVersion) {
+      return (
+        <div css={Style.mainLetterCard.hand}>
+          <LetterCard
+            variant="date"
+            apiImage={imageUrlAsBase64}
+            apiText={data?.data.content}
+            apiDate={DateTimeFormat(data.data.date)}
+          />
+        </div>
+      );
+    } else {
+      return (
+        <div css={Style.mainLetterCard.head}>
+          <LetterCard
+            variant="date"
+            apiImage={imageUrlAsBase64}
+            apiText={data?.data.content}
+            apiDate={DateTimeFormat(data.data.date)}
+          />
+        </div>
+      );
+    }
+  };
+
+  return (
+    <div id="letter">
+      <div css={Style.backgroundWrapper}>
+        {isBackgroundHandVersion ? backgroundHandVersion() : backgroundHeadVersion()}
+        <div css={Style.pageWrapper}>
+          <div ref={element1Ref}>
+            {isMounted && accessToken ? (
+              <Header leftBackPage />
+            ) : (
+              <Header
+                rightCloseButton
+                onClick={() => window.open('about:blank', '_self')?.close()}
+              />
+            )}
+          </div>
+          {data && <div>{LetterCardWithCss({ data })}</div>}
+          <div css={Style.footer.btnGroup} ref={element2Ref}>
+            <CopyLink />
+            <div css={Style.footer.bottombtn}>
+              <Button variants="secondary" onClick={handleDownload}>
+                이미지 저장
+              </Button>
+              {isMounted && (
+                <Button
+                  variants="primary"
+                  onClick={() => {
+                    if (accessToken) {
+                      router.push(
+                        {
+                          pathname: `/my-letter/edit/${activePostId}`,
+                          query: { activePostId: activePostId },
+                        },
+                        `/my-letter/edit/${activePostId}`,
+                      );
+                    }
+                  }}
+                >
+                  {accessToken ? '수정하기' : '처음으로'}
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 관련 이슈
- close #65

## 작업 내역
**1. 내가 쓴 편지 수정하기 > 상세보기, 수정하기 화면 추가**
- 내가 쓴 편지 모아보기 페이지에 상세보기, 수정하기 화면 추가
  - 편지 클릭시 > 상세보기 화면으로 연결
  - 해당 편지 > 수정하기 클릭 > 바텀시트 > 수정하기 화면으로 연결


## 전달 사항
- 편지 수정하기에서 `수정 완료하기`버튼 클릭시 원래 코드에서는 '/my-letter'로 이동하게 되어있었는데, (1) 편지에서 바로 들어올 수도있고, (2) 미리보기화면에서 바로 들어올 수도 있어서 이전 페이지로 돌아가게 하는게 낫다는 판단이 들어 코드를 수정하였습니다. 이부분 한번 검토 부탁드립니다!